### PR TITLE
Procfile locating .wsgi error fixed

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: npm start
-web: cd backend/marketio_backend && gunicorn marketio_backend.wsgi:application --bind 0.0.0.0:8000
+web: cd backend/marketio_backend && gunicorn marketio_backend.wsgi:application --bind 0.0.0.0:$PORT
 release: python backend/marketio_backend/manage.py migrate


### PR DESCRIPTION
.wsgi application was nested away from root directory - run cd command into django folder so Heroku knows where to deploy from. Changed the hard coded port into a dynamic one for Heroku to bind to.